### PR TITLE
chore(deps): bump placebrain-contracts to >=0.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "faststream[kafka]>=0.5.0",
     "greenlet>=3.3.0",
     "grpcio>=1.76.0",
-    "placebrain-contracts>=0.16.0",
+    "placebrain-contracts>=0.19.0",
     "pydantic-settings>=2.12.0",
     "sqlalchemy>=2.0.45",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -329,16 +329,16 @@ wheels = [
 
 [[package]]
 name = "placebrain-contracts"
-version = "0.16.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e5/53bcdc53c111ff7d24dc9f282af9d1d18475b611ed7ff0b5a317a896f93b/placebrain_contracts-0.16.0.tar.gz", hash = "sha256:c720b799fc60bfb5fc8a3536f2c701ab84b213c39280050e64bd30b6f319fb2f", size = 37135, upload-time = "2026-04-16T15:33:10.889Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/65/9f12774d6c5c5c9d7ed797eb72523c869aa88c0114704f909129337f171e/placebrain_contracts-0.19.0.tar.gz", hash = "sha256:b462e93e248184450095d9d60698d5539b101174b53ad995c3a4fb30b8e9730a", size = 47180, upload-time = "2026-04-17T11:25:28.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/7b/bbb044fd3bdddf8aa239f393e184e27ef8974c3f569753a6def95485737f/placebrain_contracts-0.16.0-py3-none-any.whl", hash = "sha256:04473700cbe22aab8d466fdffefdb7be1dbc6379665888bb262b2f67d67f48f6", size = 33342, upload-time = "2026-04-16T15:33:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/61/2559a0a4ac37e2944b5aedcead5b5d47b41cf2749e0cbd432d4ca20b743f/placebrain_contracts-0.19.0-py3-none-any.whl", hash = "sha256:38f93903d6b9b3805a8967c0205ae896bcda9ef6ee77fc6f9d61a4233d592497", size = 41641, upload-time = "2026-04-17T11:25:27.063Z" },
 ]
 
 [[package]]
@@ -373,7 +373,7 @@ requires-dist = [
     { name = "faststream", extras = ["kafka"], specifier = ">=0.5.0" },
     { name = "greenlet", specifier = ">=3.3.0" },
     { name = "grpcio", specifier = ">=1.76.0" },
-    { name = "placebrain-contracts", specifier = ">=0.16.0" },
+    { name = "placebrain-contracts", specifier = ">=0.19.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "sqlalchemy", specifier = ">=2.0.45" },
 ]


### PR DESCRIPTION
## Summary
Bump `placebrain-contracts` to `>=0.19.0`, which drops `BaseEvent.event_type` in favor of topic-only routing (PlaceBrain/contracts#9).

## Changes
- `pyproject.toml`: `placebrain-contracts>=0.16.0` → `>=0.19.0`
- `uv cache clean placebrain-contracts && uv lock --upgrade-package placebrain-contracts` (updated `uv.lock`)
- No source changes needed — `rg event_type src/` had no matches

## Verification
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy src` — all pass
- [x] Rebuilt `places` and `devices` in the dev stack, both reach healthy
- [x] E2E via gateway (`POST/PUT/DELETE /api/places/{id}/members`): devices logs confirm consumption on all three event types:
  - `places.member.added` → `Role cached: ... = viewer`
  - `places.member.role-changed` → `Role cache updated: ... = admin`
  - `places.member.removed` → `Role removed and MQTT creds invalidated`

Closes #3